### PR TITLE
Hotfix: Always tag published image with latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           image: bonvoyage-${{ matrix.component }}
           tag: ${{ env.image_version }}
+          tag_with_latest: true
           cache: true
           cache_registry: cache
           build_file: ./${{ matrix.component }}/Dockerfile


### PR DESCRIPTION
When an image is published, always also tag it with latest.